### PR TITLE
feat: implementar validações de segurança (issue #17)

### DIFF
--- a/src/main/java/com/fiap/fase1/dto/ChangePasswordDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/ChangePasswordDTO.java
@@ -1,8 +1,8 @@
 package com.fiap.fase1.dto;
 
+import com.fiap.fase1.validation.ValidPassword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 @Schema(description = "Dados para troca de senha do usuário")
 public record ChangePasswordDTO(
@@ -11,7 +11,7 @@ public record ChangePasswordDTO(
         String currentPassword,
 
         @NotBlank(message = "A nova senha é obrigatória")
-        @Size(min = 6, message = "A nova senha deve ter no mínimo 6 caracteres")
-        @Schema(description = "Nova senha do usuário", example = "novaSenha456")
+        @ValidPassword
+        @Schema(description = "Nova senha do usuário", example = "NovaSenha456")
         String newPassword
 ) {}

--- a/src/main/java/com/fiap/fase1/dto/UserRequestDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/UserRequestDTO.java
@@ -1,5 +1,7 @@
 package com.fiap.fase1.dto;
 
+import com.fiap.fase1.validation.SafeInput;
+import com.fiap.fase1.validation.ValidPassword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +13,7 @@ import com.fiap.fase1.model.UserType;
 public record UserRequestDTO(
         @NotBlank(message = "O nome é obrigatório")
         @Size(min = 2, max = 100, message = "O nome deve ter entre 2 e 100 caracteres")
+        @SafeInput
         @Schema(description = "Nome completo do usuário", example = "João Silva")
         String name,
 
@@ -21,16 +24,18 @@ public record UserRequestDTO(
 
         @NotBlank(message = "O login é obrigatório")
         @Size(min = 3, max = 50, message = "O login deve ter entre 3 e 50 caracteres")
+        @SafeInput
         @Schema(description = "Login do usuário", example = "joaosilva")
         String login,
 
         @NotBlank(message = "A senha é obrigatória")
-        @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres")
-        @Schema(description = "Senha do usuário", example = "senha123")
+        @ValidPassword
+        @Schema(description = "Senha do usuário", example = "Senha123")
         String password,
 
         @NotBlank(message = "O endereço é obrigatório")
         @Size(max = 255, message = "O endereço deve ter no máximo 255 caracteres")
+        @SafeInput
         @Schema(description = "Endereço do usuário", example = "Rua das Flores, 123")
         String address,
 

--- a/src/main/java/com/fiap/fase1/dto/UserUpdateDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/UserUpdateDTO.java
@@ -1,5 +1,6 @@
 package com.fiap.fase1.dto;
 
+import com.fiap.fase1.validation.SafeInput;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import com.fiap.fase1.model.UserType;
 public record UserUpdateDTO(
         @NotBlank(message = "O nome é obrigatório")
         @Size(min = 2, max = 100, message = "O nome deve ter entre 2 e 100 caracteres")
+        @SafeInput
         @Schema(description = "Nome completo do usuário", example = "João Silva")
         String name,
 
@@ -21,11 +23,13 @@ public record UserUpdateDTO(
 
         @NotBlank(message = "O login é obrigatório")
         @Size(min = 3, max = 50, message = "O login deve ter entre 3 e 50 caracteres")
+        @SafeInput
         @Schema(description = "Login do usuário", example = "joaosilva")
         String login,
 
         @NotBlank(message = "O endereço é obrigatório")
         @Size(max = 255, message = "O endereço deve ter no máximo 255 caracteres")
+        @SafeInput
         @Schema(description = "Endereço do usuário", example = "Rua das Flores, 123")
         String address,
 

--- a/src/main/java/com/fiap/fase1/model/User.java
+++ b/src/main/java/com/fiap/fase1/model/User.java
@@ -33,7 +33,7 @@ public class User {
     private String login;
 
     @NotBlank
-    @Size(min = 6)
+    @Size(min = 8)
     @Column(nullable = false)
     private String password;
 

--- a/src/main/java/com/fiap/fase1/validation/PasswordValidator.java
+++ b/src/main/java/com/fiap/fase1/validation/PasswordValidator.java
@@ -1,0 +1,16 @@
+package com.fiap.fase1.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
+
+    // min 8 chars, at least 1 uppercase, 1 lowercase, 1 digit
+    private static final String PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return false;
+        return value.matches(PASSWORD_PATTERN);
+    }
+}

--- a/src/main/java/com/fiap/fase1/validation/SafeInput.java
+++ b/src/main/java/com/fiap/fase1/validation/SafeInput.java
@@ -1,0 +1,15 @@
+package com.fiap.fase1.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = SafeInputValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SafeInput {
+    String message() default "O campo contém caracteres inválidos";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/fiap/fase1/validation/SafeInputValidator.java
+++ b/src/main/java/com/fiap/fase1/validation/SafeInputValidator.java
@@ -1,0 +1,16 @@
+package com.fiap.fase1.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class SafeInputValidator implements ConstraintValidator<SafeInput, String> {
+
+    // Rejects HTML tags and null bytes
+    private static final String DANGEROUS_PATTERN = ".*[<>\"'`\u0000].*";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+        return !value.matches(DANGEROUS_PATTERN);
+    }
+}

--- a/src/main/java/com/fiap/fase1/validation/ValidPassword.java
+++ b/src/main/java/com/fiap/fase1/validation/ValidPassword.java
@@ -1,0 +1,15 @@
+package com.fiap.fase1.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassword {
+    String message() default "A senha deve ter no mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
+++ b/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
@@ -57,7 +57,7 @@ class UserControllerTest {
     @BeforeEach
     void setUp() {
         responseDTO = new UserResponseDTO(1L, "João Silva", "joao@email.com", "joaosilva", "Rua A, 123", UserType.CUSTOMER, LocalDateTime.now());
-        requestDTO = new UserRequestDTO("João Silva", "joao@email.com", "joaosilva", "senha123", "Rua A, 123", UserType.CUSTOMER);
+        requestDTO = new UserRequestDTO("João Silva", "joao@email.com", "joaosilva", "Senha123", "Rua A, 123", UserType.CUSTOMER);
         updateDTO = new UserUpdateDTO("João Silva", "joao@email.com", "joaosilva", "Rua A, 123", UserType.CUSTOMER);
         loginResponseDTO = new LoginResponseDTO("Login realizado com sucesso", 1L, "joaosilva", "joao@email.com", LocalDateTime.now());
     }

--- a/src/test/java/com/fiap/fase1/validation/PasswordValidatorTest.java
+++ b/src/test/java/com/fiap/fase1/validation/PasswordValidatorTest.java
@@ -1,0 +1,65 @@
+package com.fiap.fase1.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordValidatorTest {
+
+    private PasswordValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new PasswordValidator();
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar senha nula")
+    void deveRejeitarSenhaNula() {
+        assertFalse(validator.isValid(null, null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar senha com menos de 8 caracteres")
+    void deveRejeitarSenhaCurta() {
+        assertFalse(validator.isValid("Ab1", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar senha sem letra maiúscula")
+    void deveRejeitarSenhaSemMaiuscula() {
+        assertFalse(validator.isValid("senha123", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar senha sem letra minúscula")
+    void deveRejeitarSenhaSemMinuscula() {
+        assertFalse(validator.isValid("SENHA123", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar senha sem número")
+    void deveRejeitarSenhaSemNumero() {
+        assertFalse(validator.isValid("SenhaForte", null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar senha válida com 8 caracteres")
+    void deveAceitarSenhaMinima() {
+        assertTrue(validator.isValid("Senha123", null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar senha válida longa")
+    void deveAceitarSenhaLonga() {
+        assertTrue(validator.isValid("MinhaSenhaSegura99", null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar senha com caracteres especiais")
+    void deveAceitarSenhaComEspeciais() {
+        assertTrue(validator.isValid("Senha@123!", null));
+    }
+}

--- a/src/test/java/com/fiap/fase1/validation/SafeInputValidatorTest.java
+++ b/src/test/java/com/fiap/fase1/validation/SafeInputValidatorTest.java
@@ -1,0 +1,71 @@
+package com.fiap.fase1.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SafeInputValidatorTest {
+
+    private SafeInputValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new SafeInputValidator();
+    }
+
+    @Test
+    @DisplayName("Deve aceitar valor nulo (responsabilidade do @NotBlank)")
+    void deveAceitarNulo() {
+        assertTrue(validator.isValid(null, null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar texto simples")
+    void deveAceitarTextoSimples() {
+        assertTrue(validator.isValid("João Silva", null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar endereço com vírgula e números")
+    void deveAceitarEndereco() {
+        assertTrue(validator.isValid("Rua das Flores, 123", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar tag HTML com <")
+    void deveRejeitarTagAbrindo() {
+        assertFalse(validator.isValid("<script>alert(1)</script>", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar input com >")
+    void deveRejeitarTagFechando() {
+        assertFalse(validator.isValid("Nome>Sobrenome", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar aspas duplas")
+    void deveRejeitarAspasDuplas() {
+        assertFalse(validator.isValid("Nome \"apelido\"", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar aspas simples")
+    void deveRejeitarAspasSimples() {
+        assertFalse(validator.isValid("Nome 'apelido'", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar backtick")
+    void deveRejeitarBacktick() {
+        assertFalse(validator.isValid("Nome `apelido`", null));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar null byte")
+    void deveRejeitarNullByte() {
+        assertFalse(validator.isValid("Nome\u0000injetado", null));
+    }
+}


### PR DESCRIPTION
## Resumo

- Adiciona anotação `@ValidPassword` com validador de força de senha (mín. 8 chars, maiúscula, minúscula e número)
- Adiciona anotação `@SafeInput` com validador de sanitização (rejeita HTML tags, aspas e null bytes)
- Aplica as anotações nos DTOs `UserRequestDTO`, `UserUpdateDTO` e `ChangePasswordDTO`
- Atualiza tamanho mínimo de senha na entidade `User` de 6 para 8 caracteres
- 17 testes unitários cobrindo todos os cenários válidos e inválidos

## Closes

Closes #17

## Test plan

- [x] `POST /api/v1/usuarios` com senha fraca retorna 400
- [x] `POST /api/v1/usuarios` com HTML no nome retorna 400
- [x] `POST /api/v1/usuarios` com payload válido retorna 201
- [x] Testes unitários: `mvn test -Dtest="PasswordValidatorTest,SafeInputValidatorTest"`