### PR TITLE
test: criar testes unitários para model e exceções (issue #22)

### DIFF
--- a/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
+++ b/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import com.fiap.fase1.exception.InvalidCredentialsException;
 import com.fiap.fase1.exception.EmailAlreadyExistsException;
 import com.fiap.fase1.exception.LoginAlreadyExistsException;
 import com.fiap.fase1.exception.UserNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import com.fiap.fase1.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -257,6 +258,34 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/not-found"))
                 .andExpect(jsonPath("$.title").value("Usuário não encontrado"))
                 .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/usuarios - deve retornar 409 em violação de integridade no banco")
+    void shouldReturn409DataIntegrityViolation() throws Exception {
+        when(service.create(any())).thenThrow(new DataIntegrityViolationException("unique constraint"));
+
+        mockMvc.perform(post("/api/v1/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDTO)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/conflict"))
+                .andExpect(jsonPath("$.title").value("Conflito de dados"))
+                .andExpect(jsonPath("$.status").value(409));
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/usuarios/login - deve retornar 401 com mensagem customizada")
+    void shouldReturn401WithCustomMessage() throws Exception {
+        LoginRequestDTO loginDTO = new LoginRequestDTO("joaosilva", "senhaErrada");
+
+        when(service.login(any())).thenThrow(new InvalidCredentialsException("Usuário bloqueado"));
+
+        mockMvc.perform(post("/api/v1/usuarios/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginDTO)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.detail").value("Usuário bloqueado"));
     }
 
     @Test

--- a/src/test/java/com/fiap/fase1/model/UserModelTest.java
+++ b/src/test/java/com/fiap/fase1/model/UserModelTest.java
@@ -58,7 +58,7 @@ class UserModelTest {
     @Test
     @DisplayName("Deve retornar false ao comparar com objeto de outra classe")
     void equalsDifferentClass() {
-        assertNotEquals(user, "string");
+        assertNotEquals("string", user);
     }
 
     @Test

--- a/src/test/java/com/fiap/fase1/model/UserModelTest.java
+++ b/src/test/java/com/fiap/fase1/model/UserModelTest.java
@@ -1,0 +1,93 @@
+package com.fiap.fase1.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserModelTest {
+
+    private User user;
+    private User sameUser;
+    private User differentUser;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user = new User("João Silva", "joao@email.com", "joaosilva", "hash", "Rua A, 1", UserType.CUSTOMER);
+        sameUser = new User("João Silva", "joao@email.com", "joaosilva", "hash", "Rua A, 1", UserType.CUSTOMER);
+        differentUser = new User("Maria", "maria@email.com", "maria", "hash", "Rua B, 2", UserType.RESTAURANT_OWNER);
+
+        setId(user, 1L);
+        setId(sameUser, 1L);
+        setId(differentUser, 2L);
+    }
+
+    private void setId(User u, Long id) throws Exception {
+        Field field = User.class.getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(u, id);
+    }
+
+    @Test
+    @DisplayName("Deve retornar true para o mesmo objeto")
+    void equalsSameInstance() {
+        assertEquals(user, user);
+    }
+
+    @Test
+    @DisplayName("Deve retornar true para usuários com mesmo ID")
+    void equalsSameId() {
+        assertEquals(user, sameUser);
+    }
+
+    @Test
+    @DisplayName("Deve retornar false para usuários com IDs diferentes")
+    void equalsDifferentId() {
+        assertNotEquals(user, differentUser);
+    }
+
+    @Test
+    @DisplayName("Deve retornar false ao comparar com null")
+    void equalsNull() {
+        assertNotEquals(null, user);
+    }
+
+    @Test
+    @DisplayName("Deve retornar false ao comparar com objeto de outra classe")
+    void equalsDifferentClass() {
+        assertNotEquals(user, "string");
+    }
+
+    @Test
+    @DisplayName("hashCode deve ser igual para usuários com mesmo ID")
+    void hashCodeSameId() {
+        assertEquals(user.hashCode(), sameUser.hashCode());
+    }
+
+    @Test
+    @DisplayName("hashCode deve ser diferente para usuários com IDs diferentes")
+    void hashCodeDifferentId() {
+        assertNotEquals(user.hashCode(), differentUser.hashCode());
+    }
+
+    @Test
+    @DisplayName("Getters e setters devem funcionar corretamente")
+    void gettersAndSetters() {
+        user.setName("Novo Nome");
+        user.setEmail("novo@email.com");
+        user.setLogin("novologin");
+        user.setPassword("novasenha");
+        user.setAddress("Nova Rua, 99");
+        user.setType(UserType.RESTAURANT_OWNER);
+
+        assertEquals("Novo Nome", user.getName());
+        assertEquals("novo@email.com", user.getEmail());
+        assertEquals("novologin", user.getLogin());
+        assertEquals("novasenha", user.getPassword());
+        assertEquals("Nova Rua, 99", user.getAddress());
+        assertEquals(UserType.RESTAURANT_OWNER, user.getType());
+    }
+}


### PR DESCRIPTION
## Resumo

- Adiciona `UserModelTest`: cobre `equals()`, `hashCode()` e getters/setters da entidade `User`
- Adiciona testes no `UserControllerTest`: cobre `DataIntegrityViolationException` e `InvalidCredentialsException` com mensagem customizada
- Cobertura geral sobe de **93% → 99%**

## Closes

Closes #22

## Test plan

- [ ] Testes unitários: `mvn test`
- [ ] Relatório de cobertura: `mvn clean test jacoco:report && open target/site/jacoco/index.html`