### PR TITLE
docs: melhorar documentação Swagger com descrições e exemplos (issue #26)

### DIFF
--- a/src/main/java/com/fiap/fase1/config/OpenApiConfig.java
+++ b/src/main/java/com/fiap/fase1/config/OpenApiConfig.java
@@ -3,8 +3,11 @@ package com.fiap.fase1.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -13,11 +16,32 @@ public class OpenApiConfig {
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("API de Gerenciamento de Usuários - Tech Challenge FIAP")
-                        .description("API RESTful para cadastro, atualização, exclusão e validação de login de usuários.")
+                        .title("API de Gerenciamento de Usuários")
+                        .description("""
+                                API RESTful para gerenciamento de usuários desenvolvida como Tech Challenge Fase 1 da FIAP.
+
+                                **Funcionalidades:**
+                                - Cadastro de usuários com validação de dados
+                                - Atualização de perfil
+                                - Exclusão de conta
+                                - Autenticação via login e senha
+                                - Troca de senha
+
+                                **Regras de senha:** mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número.
+
+                                **Tipos de usuário:** `CUSTOMER` (cliente) e `RESTAURANT_OWNER` (dono de restaurante).
+                                """)
                         .version("1.0.0")
                         .contact(new Contact()
-                                .name("FIAP - Fase 1")
-                                .url("https://github.com/jeffesa/12ADJT-fase-1")));
+                                .name("FIAP Tech Challenge - Fase 1")
+                                .url("https://github.com/jeffesa/12ADJT-fase-1")))
+                .tags(List.of(
+                        new Tag()
+                                .name("Usuários")
+                                .description("Operações de criação, consulta, atualização e exclusão de usuários"),
+                        new Tag()
+                                .name("Autenticação")
+                                .description("Operações de login e troca de senha")
+                ));
     }
 }

--- a/src/main/java/com/fiap/fase1/controller/UserController.java
+++ b/src/main/java/com/fiap/fase1/controller/UserController.java
@@ -8,10 +8,16 @@ import com.fiap.fase1.dto.UserResponseDTO;
 import com.fiap.fase1.dto.UserUpdateDTO;
 import com.fiap.fase1.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -22,7 +28,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/usuarios")
-@Tag(name = "Usuários", description = "Endpoints para gerenciamento de usuários")
+@Tag(name = "Usuários", description = "Operações de criação, consulta, atualização e exclusão de usuários")
 public class UserController {
 
     private final UserService service;
@@ -31,14 +37,54 @@ public class UserController {
         this.service = service;
     }
 
-    @Operation(summary = "Criar usuário", description = "Cadastra um novo usuário no sistema")
+    @Operation(
+        summary = "Criar usuário",
+        description = "Cadastra um novo usuário no sistema. Login e email devem ser únicos. A senha deve ter no mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número."
+    )
+    @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = UserRequestDTO.class),
+            examples = {
+                @ExampleObject(
+                    name = "Cliente",
+                    summary = "Cadastro de cliente",
+                    value = """
+                        {
+                          "name": "João Silva",
+                          "email": "joao.silva@email.com",
+                          "login": "joaosilva",
+                          "password": "Senha123",
+                          "address": "Rua das Flores, 123 - São Paulo/SP",
+                          "type": "CUSTOMER"
+                        }
+                        """
+                ),
+                @ExampleObject(
+                    name = "Dono de Restaurante",
+                    summary = "Cadastro de dono de restaurante",
+                    value = """
+                        {
+                          "name": "Maria Oliveira",
+                          "email": "maria.oliveira@restaurante.com",
+                          "login": "mariaoliveira",
+                          "password": "Restaurante1",
+                          "address": "Av. Paulista, 1000 - São Paulo/SP",
+                          "type": "RESTAURANT_OWNER"
+                        }
+                        """
+                )
+            }
+        )
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "Usuário criado com sucesso"),
-        @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+        @ApiResponse(responseCode = "400", description = "Dados inválidos — verifique os campos obrigatórios e as regras de senha"),
         @ApiResponse(responseCode = "409", description = "Email ou login já cadastrado")
     })
     @PostMapping
-    public ResponseEntity<UserResponseDTO> create(@Valid @RequestBody UserRequestDTO dto) {
+    public ResponseEntity<UserResponseDTO> create(@Valid @org.springframework.web.bind.annotation.RequestBody UserRequestDTO dto) {
         UserResponseDTO response = service.create(dto);
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -48,65 +94,137 @@ public class UserController {
         return ResponseEntity.created(location).body(response);
     }
 
-    @Operation(summary = "Listar usuários", description = "Retorna todos os usuários cadastrados")
-    @ApiResponse(responseCode = "200", description = "Lista de usuários retornada com sucesso")
+    @Operation(summary = "Listar usuários", description = "Retorna a lista completa de todos os usuários cadastrados no sistema.")
+    @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     @GetMapping
     public ResponseEntity<List<UserResponseDTO>> findAll() {
         return ResponseEntity.ok(service.findAll());
     }
 
-    @Operation(summary = "Buscar usuário por ID", description = "Retorna um usuário específico pelo ID")
+    @Operation(summary = "Buscar usuário por ID", description = "Retorna os dados de um usuário específico pelo seu ID.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Usuário encontrado"),
-        @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+        @ApiResponse(responseCode = "404", description = "Usuário não encontrado para o ID informado")
     })
     @GetMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> findById(@PathVariable Long id) {
+    public ResponseEntity<UserResponseDTO> findById(
+            @Parameter(description = "ID do usuário", example = "1", required = true)
+            @PathVariable Long id) {
         return ResponseEntity.ok(service.findById(id));
     }
 
-    @Operation(summary = "Atualizar usuário", description = "Atualiza os dados de um usuário existente")
+    @Operation(
+        summary = "Atualizar usuário",
+        description = "Atualiza os dados de um usuário existente. Não é possível alterar a senha por este endpoint — use PATCH /{id}/password."
+    )
+    @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = UserUpdateDTO.class),
+            examples = @ExampleObject(
+                name = "Atualização de perfil",
+                value = """
+                    {
+                      "name": "João Silva Atualizado",
+                      "email": "joao.novo@email.com",
+                      "login": "joaosilva",
+                      "address": "Rua Nova, 456 - São Paulo/SP",
+                      "type": "CUSTOMER"
+                    }
+                    """
+            )
+        )
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Usuário atualizado com sucesso"),
         @ApiResponse(responseCode = "400", description = "Dados inválidos"),
         @ApiResponse(responseCode = "404", description = "Usuário não encontrado"),
-        @ApiResponse(responseCode = "409", description = "Email ou login já cadastrado")
+        @ApiResponse(responseCode = "409", description = "Email ou login já cadastrado por outro usuário")
     })
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponseDTO> update(@PathVariable Long id, @Valid @RequestBody UserUpdateDTO dto) {
+    public ResponseEntity<UserResponseDTO> update(
+            @Parameter(description = "ID do usuário", example = "1", required = true)
+            @PathVariable Long id,
+            @Valid @org.springframework.web.bind.annotation.RequestBody UserUpdateDTO dto) {
         return ResponseEntity.ok(service.update(id, dto));
     }
 
-    @Operation(summary = "Deletar usuário", description = "Remove um usuário pelo ID")
+    @Operation(summary = "Deletar usuário", description = "Remove permanentemente um usuário pelo ID.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "Usuário deletado com sucesso"),
         @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
     })
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    public ResponseEntity<Void> delete(
+            @Parameter(description = "ID do usuário", example = "1", required = true)
+            @PathVariable Long id) {
         service.delete(id);
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Trocar senha", description = "Altera a senha de um usuário existente")
+    @Operation(
+        summary = "Trocar senha",
+        description = "Altera a senha de um usuário. A nova senha deve ter no mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número.",
+        tags = {"Autenticação"}
+    )
+    @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ChangePasswordDTO.class),
+            examples = @ExampleObject(
+                name = "Troca de senha",
+                value = """
+                    {
+                      "currentPassword": "SenhaAtual123",
+                      "newPassword": "NovaSenha456"
+                    }
+                    """
+            )
+        )
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Senha alterada com sucesso"),
-        @ApiResponse(responseCode = "400", description = "Senha atual incorreta ou dados inválidos"),
+        @ApiResponse(responseCode = "400", description = "Senha atual incorreta ou nova senha não atende aos requisitos"),
         @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
     })
     @PatchMapping("/{id}/password")
-    public ResponseEntity<Map<String, String>> changePassword(@PathVariable Long id, @Valid @RequestBody ChangePasswordDTO dto) {
+    public ResponseEntity<Map<String, String>> changePassword(
+            @Parameter(description = "ID do usuário", example = "1", required = true)
+            @PathVariable Long id,
+            @Valid @org.springframework.web.bind.annotation.RequestBody ChangePasswordDTO dto) {
         service.changePassword(id, dto);
         return ResponseEntity.ok(Map.of("mensagem", "Senha alterada com sucesso"));
     }
 
-    @Operation(summary = "Validar login", description = "Valida as credenciais de login do usuário")
+    @Operation(
+        summary = "Login",
+        description = "Valida as credenciais do usuário e retorna os dados da sessão.",
+        tags = {"Autenticação"}
+    )
+    @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = LoginRequestDTO.class),
+            examples = @ExampleObject(
+                name = "Login",
+                value = """
+                    {
+                      "login": "joaosilva",
+                      "password": "Senha123"
+                    }
+                    """
+            )
+        )
+    )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Login realizado com sucesso"),
-        @ApiResponse(responseCode = "401", description = "Credenciais inválidas")
+        @ApiResponse(responseCode = "401", description = "Login ou senha inválidos")
     })
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO dto) {
+    public ResponseEntity<LoginResponseDTO> login(@Valid @org.springframework.web.bind.annotation.RequestBody LoginRequestDTO dto) {
         return ResponseEntity.ok(service.login(dto));
     }
 }

--- a/src/main/java/com/fiap/fase1/dto/ChangePasswordDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/ChangePasswordDTO.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "Dados para troca de senha do usuário")
 public record ChangePasswordDTO(
         @NotBlank(message = "A senha atual é obrigatória")
-        @Schema(description = "Senha atual do usuário", example = "senha123")
+        @Schema(description = "Senha atual do usuário", example = "SenhaAtual123")
         String currentPassword,
 
         @NotBlank(message = "A nova senha é obrigatória")

--- a/src/main/java/com/fiap/fase1/dto/LoginRequestDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/LoginRequestDTO.java
@@ -10,6 +10,6 @@ public record LoginRequestDTO(
     String login,
 
     @NotBlank(message = "A senha é obrigatória")
-    @Schema(description = "Senha do usuário", example = "senha123")
+    @Schema(description = "Senha do usuário", example = "Senha123")
     String password
 ) {}

--- a/src/main/java/com/fiap/fase1/dto/UserRequestDTO.java
+++ b/src/main/java/com/fiap/fase1/dto/UserRequestDTO.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import com.fiap.fase1.model.UserType;
 
-@Schema(description = "Dados para criação ou atualização de usuário")
+@Schema(description = "Dados para criação de usuário")
 public record UserRequestDTO(
         @NotBlank(message = "O nome é obrigatório")
         @Size(min = 2, max = 100, message = "O nome deve ter entre 2 e 100 caracteres")


### PR DESCRIPTION
## Resumo

- **OpenApiConfig**: adiciona descrição completa da API com regras de negócio, tags com descrições para os grupos *Usuários* e *Autenticação*
- **UserController**: adiciona `@Parameter` nos path variables, exemplos de request body com `@ExampleObject` para todos os endpoints (incluindo dois exemplos no POST — cliente e dono de restaurante), descrições mais detalhadas em cada operação
- **DTOs**: corrige descrição do `UserRequestDTO` (era "criação ou atualização", agora "criação"), atualiza exemplos de senha para atender às regras do `@ValidPassword` (`SenhaAtual123`, `Senha123`)
- Endpoints de login e troca de senha agora aparecem também na tag *Autenticação*

## Closes

Closes #26

## Test plan

- [ ] `mvn test` — 67 testes, 0 falhas
- [ ] Acessar `http://localhost:8080/swagger-ui.html` e verificar exemplos nos endpoints