### PR TITLE
docs: documentar endpoints da API em Markdown e Postman (issue #24)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,350 @@
+# Documentação da API de Gerenciamento de Usuários
+
+Base URL: `http://localhost:8080`  
+Documentação interativa (Swagger): `http://localhost:8080/swagger-ui.html`
+
+---
+
+## DTOs
+
+### UserRequestDTO — Criação de usuário
+
+| Campo | Tipo | Obrigatório | Regras |
+|-------|------|-------------|--------|
+| `name` | string | sim | 2–100 caracteres, sem HTML |
+| `email` | string | sim | formato de e-mail válido, único |
+| `login` | string | sim | 3–50 caracteres, único, sem HTML |
+| `password` | string | sim | mín. 8 chars, 1 maiúscula, 1 minúscula, 1 número |
+| `address` | string | sim | máx. 255 caracteres, sem HTML |
+| `type` | enum | sim | `CUSTOMER` ou `RESTAURANT_OWNER` |
+
+### UserUpdateDTO — Atualização de usuário
+
+Igual ao `UserRequestDTO`, porém **sem o campo `password`**.
+
+### ChangePasswordDTO — Troca de senha
+
+| Campo | Tipo | Obrigatório | Regras |
+|-------|------|-------------|--------|
+| `currentPassword` | string | sim | senha atual do usuário |
+| `newPassword` | string | sim | mín. 8 chars, 1 maiúscula, 1 minúscula, 1 número |
+
+### LoginRequestDTO — Login
+
+| Campo | Tipo | Obrigatório |
+|-------|------|-------------|
+| `login` | string | sim |
+| `password` | string | sim |
+
+### UserResponseDTO — Retorno de usuário
+
+| Campo | Tipo |
+|-------|------|
+| `id` | number |
+| `name` | string |
+| `email` | string |
+| `login` | string |
+| `address` | string |
+| `type` | enum (`CUSTOMER` \| `RESTAURANT_OWNER`) |
+| `lastModifiedDate` | datetime (ISO 8601) |
+
+---
+
+## Endpoints
+
+### POST /api/v1/usuarios — Criar usuário
+
+**Headers**
+```
+Content-Type: application/json
+```
+
+**Request body**
+```json
+{
+  "name": "João Silva",
+  "email": "joao.silva@email.com",
+  "login": "joaosilva",
+  "password": "Senha123",
+  "address": "Rua das Flores, 123 - São Paulo/SP",
+  "type": "CUSTOMER"
+}
+```
+
+**Resposta de sucesso — 201 Created**
+```json
+{
+  "id": 1,
+  "name": "João Silva",
+  "email": "joao.silva@email.com",
+  "login": "joaosilva",
+  "address": "Rua das Flores, 123 - São Paulo/SP",
+  "type": "CUSTOMER",
+  "lastModifiedDate": "2026-04-19T10:30:00"
+}
+```
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 400 | Dados inválidos (campo obrigatório ausente, senha fraca, HTML no input) |
+| 409 | E-mail ou login já cadastrado |
+
+**Exemplo de erro 400**
+```json
+{
+  "type": "https://api.fiap.com/errors/validation",
+  "title": "Dados inválidos",
+  "status": 400,
+  "detail": "Erro de validação",
+  "instance": "/api/v1/usuarios",
+  "campos": {
+    "password": "A senha deve ter no mínimo 8 caracteres, incluindo letra maiúscula, minúscula e número"
+  }
+}
+```
+
+**Exemplo de erro 409**
+```json
+{
+  "type": "https://api.fiap.com/errors/conflict",
+  "title": "Email já cadastrado",
+  "status": 409,
+  "detail": "Email já cadastrado: joao.silva@email.com",
+  "instance": "/api/v1/usuarios"
+}
+```
+
+---
+
+### GET /api/v1/usuarios — Listar usuários
+
+**Resposta de sucesso — 200 OK**
+```json
+[
+  {
+    "id": 1,
+    "name": "João Silva",
+    "email": "joao.silva@email.com",
+    "login": "joaosilva",
+    "address": "Rua das Flores, 123 - São Paulo/SP",
+    "type": "CUSTOMER",
+    "lastModifiedDate": "2026-04-19T10:30:00"
+  }
+]
+```
+
+---
+
+### GET /api/v1/usuarios/{id} — Buscar usuário por ID
+
+**Path parameter**
+
+| Parâmetro | Tipo | Descrição |
+|-----------|------|-----------|
+| `id` | number | ID do usuário |
+
+**Resposta de sucesso — 200 OK**
+```json
+{
+  "id": 1,
+  "name": "João Silva",
+  "email": "joao.silva@email.com",
+  "login": "joaosilva",
+  "address": "Rua das Flores, 123 - São Paulo/SP",
+  "type": "CUSTOMER",
+  "lastModifiedDate": "2026-04-19T10:30:00"
+}
+```
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 404 | Usuário não encontrado |
+
+**Exemplo de erro 404**
+```json
+{
+  "type": "https://api.fiap.com/errors/not-found",
+  "title": "Usuário não encontrado",
+  "status": 404,
+  "detail": "Usuário não encontrado com id: 99",
+  "instance": "/api/v1/usuarios/99"
+}
+```
+
+---
+
+### PUT /api/v1/usuarios/{id} — Atualizar usuário
+
+**Headers**
+```
+Content-Type: application/json
+```
+
+**Path parameter**
+
+| Parâmetro | Tipo | Descrição |
+|-----------|------|-----------|
+| `id` | number | ID do usuário |
+
+**Request body**
+```json
+{
+  "name": "João Silva Atualizado",
+  "email": "joao.novo@email.com",
+  "login": "joaosilva",
+  "address": "Av. Paulista, 1000 - São Paulo/SP",
+  "type": "RESTAURANT_OWNER"
+}
+```
+
+**Resposta de sucesso — 200 OK**
+```json
+{
+  "id": 1,
+  "name": "João Silva Atualizado",
+  "email": "joao.novo@email.com",
+  "login": "joaosilva",
+  "address": "Av. Paulista, 1000 - São Paulo/SP",
+  "type": "RESTAURANT_OWNER",
+  "lastModifiedDate": "2026-04-19T11:00:00"
+}
+```
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 400 | Dados inválidos |
+| 404 | Usuário não encontrado |
+| 409 | E-mail ou login já pertence a outro usuário |
+
+---
+
+### DELETE /api/v1/usuarios/{id} — Deletar usuário
+
+**Path parameter**
+
+| Parâmetro | Tipo | Descrição |
+|-----------|------|-----------|
+| `id` | number | ID do usuário |
+
+**Resposta de sucesso — 204 No Content**
+
+*(sem corpo)*
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 404 | Usuário não encontrado |
+
+---
+
+### PATCH /api/v1/usuarios/{id}/password — Trocar senha
+
+**Headers**
+```
+Content-Type: application/json
+```
+
+**Path parameter**
+
+| Parâmetro | Tipo | Descrição |
+|-----------|------|-----------|
+| `id` | number | ID do usuário |
+
+**Request body**
+```json
+{
+  "currentPassword": "SenhaAtual123",
+  "newPassword": "NovaSenha456"
+}
+```
+
+**Resposta de sucesso — 200 OK**
+```json
+{
+  "mensagem": "Senha alterada com sucesso"
+}
+```
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 400 | Senha atual incorreta ou nova senha não atende aos requisitos |
+| 404 | Usuário não encontrado |
+
+**Exemplo de erro 400**
+```json
+{
+  "type": "https://api.fiap.com/errors/bad-request",
+  "title": "Requisição inválida",
+  "status": 400,
+  "detail": "Senha atual incorreta",
+  "instance": "/api/v1/usuarios/1/password"
+}
+```
+
+---
+
+### POST /api/v1/usuarios/login — Login
+
+**Headers**
+```
+Content-Type: application/json
+```
+
+**Request body**
+```json
+{
+  "login": "joaosilva",
+  "password": "Senha123"
+}
+```
+
+**Resposta de sucesso — 200 OK**
+```json
+{
+  "message": "Login realizado com sucesso",
+  "userId": 1,
+  "login": "joaosilva",
+  "email": "joao.silva@email.com",
+  "lastModifiedDate": "2026-04-19T10:30:00"
+}
+```
+
+**Erros**
+
+| Status | Motivo |
+|--------|--------|
+| 401 | Login ou senha inválidos |
+
+**Exemplo de erro 401**
+```json
+{
+  "type": "https://api.fiap.com/errors/unauthorized",
+  "title": "Credenciais inválidas",
+  "status": 401,
+  "detail": "Login ou senha inválidos",
+  "instance": "/api/v1/usuarios/login"
+}
+```
+
+---
+
+## Códigos de Status HTTP
+
+| Código | Significado |
+|--------|-------------|
+| 200 | Operação realizada com sucesso |
+| 201 | Recurso criado com sucesso |
+| 204 | Operação realizada sem conteúdo de retorno (ex: DELETE) |
+| 400 | Requisição inválida — dados ausentes, formato incorreto ou regras de validação não atendidas |
+| 401 | Não autorizado — credenciais inválidas |
+| 404 | Recurso não encontrado |
+| 409 | Conflito — e-mail ou login já cadastrado |

--- a/docs/api-collection/fiap-fase1-usuarios.json
+++ b/docs/api-collection/fiap-fase1-usuarios.json
@@ -1,106 +1,125 @@
 {
   "info": {
     "name": "FIAP Fase 1 - Usuarios",
+    "description": "Coleção de requisições para a API de Gerenciamento de Usuários - Tech Challenge FIAP Fase 1",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
     {
       "key": "baseUrl",
-      "value": "http://localhost:8080"
+      "value": "http://localhost:8080",
+      "description": "URL base da aplicação"
+    },
+    {
+      "key": "userId",
+      "value": "1",
+      "description": "ID do usuário para operações por ID"
     }
   ],
   "item": [
     {
-      "name": "Criar Usuario",
-      "request": {
-        "method": "POST",
-        "url": "{{baseUrl}}/api/v1/usuarios",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+      "name": "Usuários",
+      "item": [
+        {
+          "name": "Criar Usuário (CUSTOMER)",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/usuarios",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"João Silva\",\n  \"email\": \"joao.silva@email.com\",\n  \"login\": \"joaosilva\",\n  \"password\": \"Senha123\",\n  \"address\": \"Rua das Flores, 123 - São Paulo/SP\",\n  \"type\": \"CUSTOMER\"\n}"
+            }
           }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"name\": \"João Silva\",\n  \"email\": \"joao@email.com\",\n  \"login\": \"joaosilva\",\n  \"password\": \"senha123\"\n}"
-        }
-      }
-    },
-    {
-      "name": "Listar Usuarios",
-      "request": {
-        "method": "GET",
-        "url": "{{baseUrl}}/api/v1/usuarios",
-        "header": []
-      }
-    },
-    {
-      "name": "Buscar Usuario por ID",
-      "request": {
-        "method": "GET",
-        "url": "{{baseUrl}}/api/v1/usuarios/1",
-        "header": []
-      }
-    },
-    {
-      "name": "Atualizar Usuario",
-      "request": {
-        "method": "PUT",
-        "url": "{{baseUrl}}/api/v1/usuarios/1",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+        },
+        {
+          "name": "Criar Usuário (RESTAURANT_OWNER)",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/usuarios",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Maria Oliveira\",\n  \"email\": \"maria.oliveira@restaurante.com\",\n  \"login\": \"mariaoliveira\",\n  \"password\": \"Restaurante1\",\n  \"address\": \"Av. Paulista, 1000 - São Paulo/SP\",\n  \"type\": \"RESTAURANT_OWNER\"\n}"
+            }
           }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"name\": \"João Atualizado\",\n  \"email\": \"joao@email.com\",\n  \"login\": \"joaosilva\",\n  \"password\": \"novaSenha123\"\n}"
-        }
-      }
-    },
-    {
-      "name": "Deletar Usuario",
-      "request": {
-        "method": "DELETE",
-        "url": "{{baseUrl}}/api/v1/usuarios/1",
-        "header": []
-      }
-    },
-    {
-      "name": "Login",
-      "request": {
-        "method": "POST",
-        "url": "{{baseUrl}}/api/v1/usuarios/login",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+        },
+        {
+          "name": "Listar Usuários",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/usuarios",
+            "header": []
           }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"login\": \"joaosilva\",\n  \"password\": \"senha123\"\n}"
+        },
+        {
+          "name": "Buscar Usuário por ID",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/api/v1/usuarios/{{userId}}",
+            "header": []
+          }
+        },
+        {
+          "name": "Atualizar Usuário",
+          "request": {
+            "method": "PUT",
+            "url": "{{baseUrl}}/api/v1/usuarios/{{userId}}",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"João Silva Atualizado\",\n  \"email\": \"joao.novo@email.com\",\n  \"login\": \"joaosilva\",\n  \"address\": \"Av. Paulista, 1000 - São Paulo/SP\",\n  \"type\": \"RESTAURANT_OWNER\"\n}"
+            }
+          }
+        },
+        {
+          "name": "Deletar Usuário",
+          "request": {
+            "method": "DELETE",
+            "url": "{{baseUrl}}/api/v1/usuarios/{{userId}}",
+            "header": []
+          }
         }
-      }
+      ]
     },
     {
-      "name": "Login - Credenciais Inválidas",
-      "request": {
-        "method": "POST",
-        "url": "{{baseUrl}}/api/v1/usuarios/login",
-        "header": [
-          {
-            "key": "Content-Type",
-            "value": "application/json"
+      "name": "Autenticação",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/api/v1/usuarios/login",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"login\": \"joaosilva\",\n  \"password\": \"Senha123\"\n}"
+            }
           }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"login\": \"joaosilva\",\n  \"password\": \"senhaErrada\"\n}"
+        },
+        {
+          "name": "Trocar Senha",
+          "request": {
+            "method": "PATCH",
+            "url": "{{baseUrl}}/api/v1/usuarios/{{userId}}/password",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"currentPassword\": \"SenhaAtual123\",\n  \"newPassword\": \"NovaSenha456\"\n}"
+            }
+          }
         }
-      }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Resumo

- Cria `docs/API.md` com documentação completa de todos os endpoints
- Atualiza `docs/api-collection/fiap-fase1-usuarios.json` (collection Postman desatualizada — faltavam campos `address`, `type` e senhas fora do padrão)

## Critérios atendidos

- [x] Especificação de cada endpoint (método HTTP, path, descrição)
- [x] Exemplos de request (body e headers)
- [x] Exemplos de response (sucesso e erro)
- [x] Explicação dos códigos HTTP (200, 201, 204, 400, 401, 404, 409)
- [x] Especificação dos DTOs com tipos e regras de validação
- [x] Formato Markdown + Swagger/OpenAPI (via issue #26 já mergeada)

## Closes

Closes #24