### PR TITLE
refactor: aplicar boas práticas e clean code (issue #29)

### DIFF
--- a/openjdk.jdk
+++ b/openjdk.jdk
@@ -1,0 +1,1 @@
+/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk

--- a/src/main/java/com/fiap/fase1/controller/UserController.java
+++ b/src/main/java/com/fiap/fase1/controller/UserController.java
@@ -185,9 +185,46 @@ public class UserController {
         )
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Senha alterada com sucesso"),
-        @ApiResponse(responseCode = "400", description = "Senha atual incorreta ou nova senha não atende aos requisitos"),
-        @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+        @ApiResponse(
+            responseCode = "200",
+            description = "Senha alterada com sucesso",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = @ExampleObject(value = "{\"mensagem\": \"Senha alterada com sucesso\"}")
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Senha atual incorreta ou nova senha não atende aos requisitos",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = @ExampleObject(value = """
+                    {
+                      "type": "https://api.fiap.com/errors/bad-request",
+                      "title": "Requisição inválida",
+                      "status": 400,
+                      "detail": "Senha atual incorreta",
+                      "instance": "/api/v1/usuarios/1/password"
+                    }
+                    """)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Usuário não encontrado",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                examples = @ExampleObject(value = """
+                    {
+                      "type": "https://api.fiap.com/errors/not-found",
+                      "title": "Usuário não encontrado",
+                      "status": 404,
+                      "detail": "Usuário não encontrado com id: 1",
+                      "instance": "/api/v1/usuarios/1/password"
+                    }
+                    """)
+            )
+        )
     })
     @PatchMapping("/{id}/password")
     public ResponseEntity<Map<String, String>> changePassword(

--- a/src/main/java/com/fiap/fase1/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiap/fase1/exception/GlobalExceptionHandler.java
@@ -13,74 +13,51 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    private static final URI TYPE_NOT_FOUND = URI.create("https://api.fiap.com/errors/not-found");
-    private static final URI TYPE_CONFLICT = URI.create("https://api.fiap.com/errors/conflict");
+    private static final URI TYPE_NOT_FOUND    = URI.create("https://api.fiap.com/errors/not-found");
+    private static final URI TYPE_CONFLICT     = URI.create("https://api.fiap.com/errors/conflict");
     private static final URI TYPE_UNAUTHORIZED = URI.create("https://api.fiap.com/errors/unauthorized");
-    private static final URI TYPE_VALIDATION = URI.create("https://api.fiap.com/errors/validation");
-    private static final URI TYPE_BAD_REQUEST = URI.create("https://api.fiap.com/errors/bad-request");
+    private static final URI TYPE_VALIDATION   = URI.create("https://api.fiap.com/errors/validation");
+    private static final URI TYPE_BAD_REQUEST  = URI.create("https://api.fiap.com/errors/bad-request");
 
     @ExceptionHandler(UserNotFoundException.class)
     public ProblemDetail handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
         log.warn("Usuário não encontrado: {} | Path: {}", ex.getMessage(), request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
-        problem.setTitle("Usuário não encontrado");
-        problem.setType(TYPE_NOT_FOUND);
-        problem.setInstance(URI.create(request.getRequestURI()));
-        return problem;
+        return buildProblem(HttpStatus.NOT_FOUND, ex.getMessage(), "Usuário não encontrado", TYPE_NOT_FOUND, request);
     }
 
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ProblemDetail handleEmailAlreadyExists(EmailAlreadyExistsException ex, HttpServletRequest request) {
         log.warn("Email duplicado: {} | Path: {}", ex.getMessage(), request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
-        problem.setTitle("Email já cadastrado");
-        problem.setType(TYPE_CONFLICT);
-        problem.setInstance(URI.create(request.getRequestURI()));
-        return problem;
+        return buildProblem(HttpStatus.CONFLICT, ex.getMessage(), "Email já cadastrado", TYPE_CONFLICT, request);
     }
 
     @ExceptionHandler(LoginAlreadyExistsException.class)
     public ProblemDetail handleLoginAlreadyExists(LoginAlreadyExistsException ex, HttpServletRequest request) {
         log.warn("Login duplicado: {} | Path: {}", ex.getMessage(), request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
-        problem.setTitle("Login já cadastrado");
-        problem.setType(TYPE_CONFLICT);
-        problem.setInstance(URI.create(request.getRequestURI()));
-        return problem;
+        return buildProblem(HttpStatus.CONFLICT, ex.getMessage(), "Login já cadastrado", TYPE_CONFLICT, request);
     }
 
     @ExceptionHandler(InvalidCredentialsException.class)
     public ProblemDetail handleInvalidCredentials(InvalidCredentialsException ex, HttpServletRequest request) {
         log.warn("Credenciais inválidas | Path: {}", request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, ex.getMessage());
-        problem.setTitle("Credenciais inválidas");
-        problem.setType(TYPE_UNAUTHORIZED);
-        problem.setInstance(URI.create(request.getRequestURI()));
-        return problem;
+        return buildProblem(HttpStatus.UNAUTHORIZED, ex.getMessage(), "Credenciais inválidas", TYPE_UNAUTHORIZED, request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ProblemDetail handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
-        String errors = ex.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.joining("; "));
-        log.warn("Validação falhou: {} | Path: {}", errors, request.getRequestURI());
-
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Erro de validação");
-        problem.setTitle("Dados inválidos");
-        problem.setType(TYPE_VALIDATION);
-        problem.setInstance(URI.create(request.getRequestURI()));
-
         Map<String, String> fieldErrors = new LinkedHashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error ->
                 fieldErrors.put(error.getField(), error.getDefaultMessage()));
+
+        log.warn("Validação falhou: {} | Path: {}", fieldErrors, request.getRequestURI());
+
+        ProblemDetail problem = buildProblem(HttpStatus.BAD_REQUEST, "Erro de validação", "Dados inválidos", TYPE_VALIDATION, request);
         problem.setProperty("campos", fieldErrors);
         return problem;
     }
@@ -88,19 +65,19 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ProblemDetail handleDataIntegrity(DataIntegrityViolationException ex, HttpServletRequest request) {
         log.error("Violação de integridade de dados: {} | Path: {}", ex.getMostSpecificCause().getMessage(), request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, "Violação de integridade de dados");
-        problem.setTitle("Conflito de dados");
-        problem.setType(TYPE_CONFLICT);
-        problem.setInstance(URI.create(request.getRequestURI()));
-        return problem;
+        return buildProblem(HttpStatus.CONFLICT, "Violação de integridade de dados", "Conflito de dados", TYPE_CONFLICT, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ProblemDetail handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
         log.warn("Argumento inválido: {} | Path: {}", ex.getMessage(), request.getRequestURI());
-        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
-        problem.setTitle("Requisição inválida");
-        problem.setType(TYPE_BAD_REQUEST);
+        return buildProblem(HttpStatus.BAD_REQUEST, ex.getMessage(), "Requisição inválida", TYPE_BAD_REQUEST, request);
+    }
+
+    private ProblemDetail buildProblem(HttpStatus status, String detail, String title, URI type, HttpServletRequest request) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, detail);
+        problem.setTitle(title);
+        problem.setType(type);
         problem.setInstance(URI.create(request.getRequestURI()));
         return problem;
     }

--- a/src/main/java/com/fiap/fase1/repository/UserRepository.java
+++ b/src/main/java/com/fiap/fase1/repository/UserRepository.java
@@ -17,5 +17,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByLogin(String login);
 
-    Optional<User> findByLoginAndPassword(String login, String password);
 }

--- a/src/main/java/com/fiap/fase1/service/UserService.java
+++ b/src/main/java/com/fiap/fase1/service/UserService.java
@@ -110,10 +110,11 @@ public class UserService {
         log.info("Tentativa de login para o usuário: {}", dto.login());
 
         User user = repository.findByLogin(dto.login())
-                .orElseThrow(() -> {
-                    log.warn("Tentativa de login falhou - usuário não encontrado: {}", dto.login());
-                    return new InvalidCredentialsException();
-                });
+                .orElse(null);
+        if (user == null) {
+            log.warn("Tentativa de login falhou - usuário não encontrado: {}", dto.login());
+            throw new InvalidCredentialsException();
+        }
 
         if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
             log.warn("Tentativa de login falhou - senha incorreta para o usuário: {}", dto.login());

--- a/src/main/java/com/fiap/fase1/validation/PasswordValidator.java
+++ b/src/main/java/com/fiap/fase1/validation/PasswordValidator.java
@@ -5,7 +5,6 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class PasswordValidator implements ConstraintValidator<ValidPassword, String> {
 
-    // min 8 chars, at least 1 uppercase, 1 lowercase, 1 digit
     private static final String PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{8,}$";
 
     @Override

--- a/src/main/java/com/fiap/fase1/validation/SafeInputValidator.java
+++ b/src/main/java/com/fiap/fase1/validation/SafeInputValidator.java
@@ -5,7 +5,6 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class SafeInputValidator implements ConstraintValidator<SafeInput, String> {
 
-    // Rejects HTML tags and null bytes
     private static final String DANGEROUS_PATTERN = ".*[<>\"'`\u0000].*";
 
     @Override

--- a/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
+++ b/src/test/java/com/fiap/fase1/controller/UserControllerTest.java
@@ -289,6 +289,71 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("GET /api/v1/usuarios - deve retornar lista vazia")
+    void shouldReturnEmptyList() throws Exception {
+        when(service.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/usuarios"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/usuarios/{id} - deve retornar 409 com email de outro usuário")
+    void shouldReturn409UpdateDuplicateEmail() throws Exception {
+        when(service.update(eq(1L), any())).thenThrow(new EmailAlreadyExistsException("joao@email.com"));
+
+        mockMvc.perform(put("/api/v1/usuarios/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/conflict"))
+                .andExpect(jsonPath("$.title").value("Email já cadastrado"))
+                .andExpect(jsonPath("$.status").value(409));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/usuarios/{id} - deve retornar 409 com login de outro usuário")
+    void shouldReturn409UpdateDuplicateLogin() throws Exception {
+        when(service.update(eq(1L), any())).thenThrow(new LoginAlreadyExistsException("joaosilva"));
+
+        mockMvc.perform(put("/api/v1/usuarios/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/conflict"))
+                .andExpect(jsonPath("$.title").value("Login já cadastrado"))
+                .andExpect(jsonPath("$.status").value(409));
+    }
+
+    @Test
+    @DisplayName("PUT /api/v1/usuarios/{id} - deve retornar 400 com dados inválidos")
+    void shouldReturn400UpdateInvalidData() throws Exception {
+        UserUpdateDTO invalid = new UserUpdateDTO("", "email-invalido", "login", "Rua A", UserType.CUSTOMER);
+
+        mockMvc.perform(put("/api/v1/usuarios/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/validation"))
+                .andExpect(jsonPath("$.campos").exists());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/usuarios/{id}/password - deve retornar 400 com nova senha fraca")
+    void shouldReturn400WeakNewPassword() throws Exception {
+        ChangePasswordDTO dto = new ChangePasswordDTO("SenhaAtual123", "fraca");
+
+        mockMvc.perform(patch("/api/v1/usuarios/1/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("https://api.fiap.com/errors/validation"))
+                .andExpect(jsonPath("$.campos").exists());
+    }
+
+    @Test
     @DisplayName("POST /api/v1/usuarios - deve retornar 409 ProblemDetail com login duplicado")
     void shouldReturn409DuplicateLogin() throws Exception {
         when(service.create(any())).thenThrow(new LoginAlreadyExistsException("joaosilva"));

--- a/src/test/java/com/fiap/fase1/model/UserModelTest.java
+++ b/src/test/java/com/fiap/fase1/model/UserModelTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -71,6 +72,22 @@ class UserModelTest {
     @DisplayName("hashCode deve ser diferente para usuários com IDs diferentes")
     void hashCodeDifferentId() {
         assertNotEquals(user.hashCode(), differentUser.hashCode());
+    }
+
+    @Test
+    @DisplayName("Construtor padrão deve criar instância não nula")
+    void defaultConstructorCreatesInstance() {
+        assertNotNull(new User());
+    }
+
+    @Test
+    @DisplayName("updateLastModifiedDate deve definir timestamp ao persistir")
+    void updateLastModifiedDateSetsTimestamp() throws Exception {
+        User newUser = new User();
+        Method method = User.class.getDeclaredMethod("updateLastModifiedDate");
+        method.setAccessible(true);
+        method.invoke(newUser);
+        assertNotNull(newUser.getLastModifiedDate());
     }
 
     @Test

--- a/src/test/java/com/fiap/fase1/repository/UserRepositoryTest.java
+++ b/src/test/java/com/fiap/fase1/repository/UserRepositoryTest.java
@@ -77,4 +77,36 @@ class UserRepositoryTest {
         assertFalse(repository.existsByLogin("naoexiste"));
     }
 
+    @Test
+    @DisplayName("findAll deve retornar todos os usuários salvos")
+    void shouldFindAllSavedUsers() {
+        repository.save(new User("Maria", "maria@email.com", "maria", "senha_hash", "Rua B, 456", UserType.RESTAURANT_OWNER));
+
+        assertEquals(2, repository.findAll().size());
+    }
+
+    @Test
+    @DisplayName("deleteById deve remover o usuário")
+    void shouldDeleteById() {
+        Long id = repository.findByLogin("joaosilva").get().getId();
+
+        repository.deleteById(id);
+
+        assertFalse(repository.existsById(id));
+    }
+
+    @Test
+    @DisplayName("existsById deve retornar true para usuário existente")
+    void shouldReturnTrueExistingId() {
+        Long id = repository.findByLogin("joaosilva").get().getId();
+
+        assertTrue(repository.existsById(id));
+    }
+
+    @Test
+    @DisplayName("existsById deve retornar false para ID inexistente")
+    void shouldReturnFalseNonExistingId() {
+        assertFalse(repository.existsById(9999L));
+    }
+
 }

--- a/src/test/java/com/fiap/fase1/repository/UserRepositoryTest.java
+++ b/src/test/java/com/fiap/fase1/repository/UserRepositoryTest.java
@@ -77,17 +77,4 @@ class UserRepositoryTest {
         assertFalse(repository.existsByLogin("naoexiste"));
     }
 
-    @Test
-    @DisplayName("Deve encontrar usuário por login e senha")
-    void shouldFindByLoginAndPassword() {
-        Optional<User> result = repository.findByLoginAndPassword("joaosilva", "senha_hash");
-        assertTrue(result.isPresent());
-        assertEquals("joaosilva", result.get().getLogin());
-    }
-
-    @Test
-    @DisplayName("Deve retornar vazio ao buscar login e senha incorretos")
-    void shouldReturnEmptyWrongLoginAndPassword() {
-        assertTrue(repository.findByLoginAndPassword("joaosilva", "senha_errada").isEmpty());
-    }
 }

--- a/src/test/java/com/fiap/fase1/service/UserServiceTest.java
+++ b/src/test/java/com/fiap/fase1/service/UserServiceTest.java
@@ -113,6 +113,14 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("Deve retornar lista vazia quando não há usuários")
+    void shouldReturnEmptyListWhenNoUsers() {
+        when(repository.findAll()).thenReturn(List.of());
+
+        assertTrue(service.findAll().isEmpty());
+    }
+
+    @Test
     @DisplayName("Deve buscar usuário por ID com sucesso")
     void shouldFindById() {
         when(repository.findById(1L)).thenReturn(Optional.of(user));
@@ -183,6 +191,17 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("Deve atualizar sem conflito ao manter o próprio email e login")
+    void shouldUpdateWithSameEmailAndLoginNoConflict() {
+        when(repository.findById(1L)).thenReturn(Optional.of(user));
+        when(repository.findByEmail(updateDTO.email())).thenReturn(Optional.of(user));
+        when(repository.findByLogin(updateDTO.login())).thenReturn(Optional.of(user));
+        when(repository.save(any(User.class))).thenReturn(user);
+
+        assertDoesNotThrow(() -> service.update(1L, updateDTO));
+    }
+
+    @Test
     @DisplayName("Deve lançar exceção ao atualizar usuário inexistente")
     void shouldThrowExceptionUpdateNonExistent() {
         when(repository.findById(99L)).thenReturn(Optional.empty());
@@ -246,7 +265,7 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("Deve trocar senha com sucesso")
+    @DisplayName("Deve trocar senha com sucesso e salvar novo hash")
     void shouldChangePassword() {
         ChangePasswordDTO dto = new ChangePasswordDTO("senha123", "novaSenha456");
 
@@ -257,7 +276,8 @@ class UserServiceTest {
 
         service.changePassword(1L, dto);
 
-        verify(repository).save(any(User.class));
+        assertEquals("nova_senha_hash", user.getPassword());
+        verify(repository).save(user);
     }
 
     @Test


### PR DESCRIPTION
## Resumo

Revisão do código-fonte aplicando boas práticas e clean code (issue #29).

- **DRY** — `GlobalExceptionHandler`: extrai `buildProblem()` eliminando 5 blocos idênticos de 4 linhas cada
- **Código morto** — `UserRepository`: remove `findByLoginAndPassword` (nunca usado pelo serviço, que usa BCrypt para comparação de senha)
- **Legibilidade** — `UserService.login()`: move log para fora do lambda `orElse`, padrão mais idiomático
- **Comentários WHAT** — Remove comentários que explicam o que o código faz (redundante com nomes dos símbolos) em `PasswordValidator` e `SafeInputValidator`

## Checklist

- [x] 105 testes passando
- [x] Sem warnings de compilação
- [x] Nomenclaturas seguindo convenções Java
- [x] Princípios SOLID e DRY respeitados

Closes #29